### PR TITLE
Fix fatal on get_users call from hm-timezones

### DIFF
--- a/includes/api-users.php
+++ b/includes/api-users.php
@@ -28,7 +28,7 @@ class HM_Time_API_Users {
 	/**
 	 * Retrieve users time data.
 	 */
-	public function get_users( WP_REST_Request $request ) {
+	public function get_users( $request = null ) {
 
 		$args = '';
 


### PR DESCRIPTION
remove type hinting from get_users arg and add default